### PR TITLE
Remove duplicate key; keep "index"

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -5,7 +5,6 @@
   },
   "i18n": {
     "title": {
-      "ar": "جدول الوظائف",
       "ar": "الفهرس",
       "en": "Dashboard",
       "fr": "Tableau de bord",


### PR DESCRIPTION
There were two "ar" entries for "title". Now there is only one. The keeps the "index" one.