### PR TITLE
changement du lien pour accéder directement au contenu à télécharger

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,7 +112,7 @@ function App() {
                             label={doI18n("pages:core-dashboard:download_from_internet", i18nRef.current)} 
                             color='secondary' 
                             variant="outlined"
-                            onClick={() => window.location.href = '/clients/content'}
+                            onClick={() => window.location.href = '/clients/download'}
                         />
                     }
                     <Chip label={doI18n("pages:core-dashboard:create_content", i18nRef.current)} color='secondary' variant="outlined" onClick={() => window.location.href = '/clients/content'} />


### PR DESCRIPTION
Changement du chemin pour accéder directement à la popup download directement en passant par le raccourci situé sur la page dashboard