### PR TITLE
Now filtering with interfaces

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -233,7 +233,7 @@ function App() {
                       await postEmptyJson(
                         `/app-state/current-project/${repo[0]}`
                       );
-                      window.location.href = "/clients/local-projects";
+                      window.location.href = "/clients/core-local-workspace";
                     } else {
                       console.log("Metadata fetch failed");
                       console.log(fullMetadataResponse);


### PR DESCRIPTION
Now, removing interfaces from the app prevents users from trying to edit flavors.