### PR TITLE
Remember step, create component walkthrough could be move to rcl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.5",
-        "pankosmia-rcl": "^0.1.43",
+        "pankosmia-rcl": "0.1.45",
         "pithekos-lib": "^0.11.20",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
@@ -13616,9 +13616,9 @@
       }
     },
     "node_modules/pankosmia-rcl": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/pankosmia-rcl/-/pankosmia-rcl-0.1.43.tgz",
-      "integrity": "sha512-9aQAMjJ55yPToM+5nZFK/7SY8bC64FSjMZdd4/Hm8WKufYNqEZcIY+a/ViXGdxfKQVzBFvViNisYY5tW52f1OQ==",
+      "version": "0.1.45",
+      "resolved": "https://registry.npmjs.org/pankosmia-rcl/-/pankosmia-rcl-0.1.45.tgz",
+      "integrity": "sha512-Gf2gSrZ+NlVhgWCjYFF5hVMS0Rzm9up7yEHXxzvuubrEJWctXAW8QSLqgTqAP68o6PV/QNT4vxnjjnBj43TlDA==",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.5",
-    "pankosmia-rcl": "^0.1.43",
+    "pankosmia-rcl": "0.1.45",
     "pithekos-lib": "^0.11.20",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -3,6 +3,7 @@
   "require": {
     "net": false
   },
+  "minServerVersion": "0.14.12",
   "i18n": {
     "title": {
       "ar": "الفهرس",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ import SaveAsOutlinedIcon from "@mui/icons-material/SaveAsOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import SvgVersionManager from "./fileIcon/iconVersionManager";
 import Markdown from "react-markdown";
-
+import { Walkthrough } from "./Walkthrough";
 const getEditDocumentKeys = (data) => {
   let map = {};
   for (let [l, v] of Object.entries(data)) {
@@ -51,9 +51,7 @@ function App() {
   const [showWelcome, setShowWelcome] = useState(
     localStorage.getItem("showWelcome") === null ? true : false,
   );
-  const [showInitialWorkflow, setShowInitialWorkflow] = useState(
-    localStorage.getItem("showInitialWorkflow") === null ? true : false,
-  );
+
   const [clientInterfaces, setClientInterfaces] = useState({});
   const [createAnchorEl, setCreateAnchorEl] = useState(null);
   const { i18nRef } = useContext(i18nContext);
@@ -71,10 +69,6 @@ function App() {
   const [subMenuButtonSave, setSubMenuButtonSave] = useState(null);
   const [subMenuAboutRepo, setSubMenuAboutRepo] = useState(null);
   const [openSubMenu, setOpenSubMenu] = useState(null);
-  const [currentLanguages, setCurrentLanguages] = useState();
-  const [walkthrough, setWalkthrough] = useState(null);
-  const [walkthroughIndex, setWalkthroughIndex] = useState(null);
-  const [showWalkthrough, setShowWalkthrough] = useState(false);
 
   const createItems = (() => {
     if (!clientInterfaces) return [];
@@ -105,6 +99,7 @@ function App() {
       setProjectSummaries(summariesResponse.json);
     }
   };
+
   useEffect(() => {
     getProjectSummaries().then();
   }, []);
@@ -119,15 +114,6 @@ function App() {
     }).then();
   }, []);
 
-  useEffect(() => {
-    getJson("/settings/languages")
-      .then((res) => res.json)
-      .then((data) => {
-        setCurrentLanguages(data);
-      })
-      .catch((err) => console.error("Error :", err));
-  }, []);
-
   const handleSubMenuClick = (event) => {
     setSubMenuButtonSave(event.currentTarget);
   };
@@ -136,57 +122,12 @@ function App() {
     getJson("/client-interfaces")
       .then((res) => res.json)
       .then((data) => {
+        PanStepperPicker;
         setEditTable(getEditDocumentKeys(data));
         setClientInterfaces(data);
       })
       .catch((err) => console.error("Error :", err));
   }, []);
-
-  const getWalkthroughContent = async (languagesArray) => {
-    for (const lang of languagesArray) {
-      const response = await fetch(
-        `/content-utils/product?resource_path=core-client-dashboard/walk_thru/${lang}/index.json`,
-      );
-
-      if (response.ok) {
-        const indexData = await response.json();
-
-        const finalGuide = await Promise.all(
-          indexData.steps.map(async (step) => {
-            const mdResponse = await fetch(
-              `/content-utils/product?resource_path=core-client-dashboard/walk_thru/${lang}/${step.bodyPath}`,
-            );
-            const mdText = mdResponse.ok
-              ? await mdResponse.text()
-              : "Content unavailable";
-
-            return {
-              name: step.title,
-              content: mdText,
-            };
-          }),
-        );
-
-        setWalkthroughIndex(indexData);
-        setWalkthrough({
-          title: indexData.name,
-          steps: finalGuide,
-        });
-        setShowWalkthrough(true);
-        return;
-      }
-    }
-
-    console.warn("No walkthrough found in any language.");
-    setShowWalkthrough(false);
-    setWalkthrough(null);
-  };
-
-  useEffect(() => {
-    if (currentLanguages && currentLanguages.length > 0) {
-      getWalkthroughContent(currentLanguages).then();
-    }
-  }, [currentLanguages]);
 
   let createItemExport;
   let createAboutRepo;
@@ -272,49 +213,6 @@ function App() {
     "x-tcore": "parascriptural",
   };
 
-  const steps = [
-    walkthrough?.steps[0]?.name,
-    walkthrough?.steps[1]?.name,
-    walkthrough?.steps[2]?.name,
-  ];
-
-  const renderStepContent = (step) => {
-    switch (step) {
-      case 0:
-        return <Markdown fullWidth>{walkthrough?.steps[0]?.content}</Markdown>;
-      case 1:
-        return <Markdown fullWidth>{walkthrough?.steps[1]?.content}</Markdown>;
-      case 2:
-        return <Markdown fullWidth>{walkthrough?.steps[2]?.content}</Markdown>;
-      default:
-        return null;
-    }
-  };
-
-  const isStepValid = (step) => {
-    switch (step) {
-      case 0:
-        return showInitialWorkflow;
-
-      case 1:
-        return showInitialWorkflow;
-      case 2:
-        return showInitialWorkflow;
-      default:
-        return true;
-    }
-  };
-
-  const handleCreate = async () => {
-    setShowInitialWorkflow(false);
-    localStorage.setItem("showInitialWorkflow", "initialWorkflowIsDisabled");
-  };
-
-  const handleClose = () => {
-    setShowInitialWorkflow(false);
-    localStorage.setItem("showInitialWorkflow", "initialWorkflowIsDisabled");
-  };
-
   return (
     <Box
       sx={{
@@ -361,29 +259,7 @@ function App() {
             </Card>
           </Grid2>
         )}
-        {!showWelcome && showInitialWorkflow && walkthrough && (
-          <Grid2 item size={12}>
-            <Card elevation={1} sx={{ backgroundColor: "#E5F6FD" }}>
-              <CardContent>
-                <Typography variant="h5" component="div">
-                  {walkthrough.title}
-                </Typography>
-                <PanStepperPicker
-                  steps={steps}
-                  renderStepContent={renderStepContent}
-                  isStepValid={isStepValid}
-                  handleCreate={handleCreate}
-                  handleClose={handleClose}
-                  requiredFieldsLabel={false}
-                  primaryActionKey="close"
-                  primaryButtonVariant="primary"
-                  secondaryActionKey="back_button"
-                  secondaryButtonVariant="secondary"
-                />
-              </CardContent>
-            </Card>
-          </Grid2>
-        )}
+        {!showWelcome && <Walkthrough />}
         <Grid2 item size={12}>
           <Stack direction="row" spacing={1}>
             <Chip

--- a/src/Walkthrough.jsx
+++ b/src/Walkthrough.jsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import Markdown from "react-markdown";
+import { PanStepperPicker } from "pankosmia-rcl";
+import { getJson } from "pithekos-lib";
+import { Grid2, Card, CardContent, Typography } from "@mui/material";
+export function Walkthrough() {
+  const [currentLanguages, setCurrentLanguages] = useState();
+  const [walkthrough, setWalkthrough] = useState(null);
+  const [walkthroughIndex, setWalkthroughIndex] = useState(null);
+  const [showWalkthrough, setShowWalkthrough] = useState(false);
+  const [initStep, setInitStep] = useState(1);
+  const [showInitialWorkflow, setShowInitialWorkflow] = useState(
+    localStorage.getItem("showInitialWorkflow") === null ? true : false,
+  );
+  useEffect(() => {
+    getJson("/settings/languages")
+      .then((res) => res.json)
+      .then((data) => {
+        setCurrentLanguages(data);
+      })
+      .catch((err) => console.error("Error :", err));
+  }, []);
+  const getWalkthroughContent = async (languagesArray) => {
+    for (const lang of languagesArray) {
+      const response = await fetch(
+        `/content-utils/product?resource_path=core-client-dashboard/walk_thru/${lang}/index.json`,
+      );
+
+      if (response.ok) {
+        const indexData = await response.json();
+
+        const finalGuide = await Promise.all(
+          indexData.steps.map(async (step) => {
+            const mdResponse = await fetch(
+              `/content-utils/product?resource_path=core-client-dashboard/walk_thru/${lang}/${step.bodyPath}`,
+            );
+            const mdText = mdResponse.ok
+              ? await mdResponse.text()
+              : "Content unavailable";
+
+            return {
+              name: step.title,
+              content: mdText,
+            };
+          }),
+        );
+
+        setWalkthroughIndex(indexData);
+        setWalkthrough({
+          title: indexData.name,
+          steps: finalGuide,
+        });
+        setShowWalkthrough(true);
+        return;
+      }
+    }
+
+    console.warn("No walkthrough found in any language.");
+    setShowWalkthrough(false);
+    setWalkthrough(null);
+  };
+
+  useEffect(() => {
+    let array = JSON.parse(
+      localStorage.getItem("HistoriqueInitialWorkflow") || "[]",
+    );
+    if (array.length < 1) {
+      localStorage.setItem("HistoriqueInitialWorkflow", "[]");
+      return;
+    } else if (array.length > 0) {
+      let init = array.pop();
+      setInitStep(init);
+    }
+    localStorage.setItem("HistoriqueInitialWorkflow", JSON.stringify(array));
+  }, []);
+  const isStepValid = (step) => {
+    console.log("ici");
+    switch (step) {
+      case 0:
+        return showInitialWorkflow;
+      case 1:
+        return showInitialWorkflow;
+      case 2:
+        return showInitialWorkflow;
+      default:
+        return true;
+    }
+  };
+  const renderStepContent = (step) => {
+    let array;
+    switch (step) {
+      case 0:
+        array = JSON.parse(localStorage.getItem("HistoriqueInitialWorkflow"));
+        array.push(0 + 1);
+        localStorage.setItem(
+          "HistoriqueInitialWorkflow",
+          JSON.stringify(array),
+        );
+        return <Markdown fullWidth>{walkthrough?.steps[0]?.content}</Markdown>;
+      case 1:
+        array = JSON.parse(localStorage.getItem("HistoriqueInitialWorkflow"));
+        array.push(1 + 1);
+        localStorage.setItem(
+          "HistoriqueInitialWorkflow",
+          JSON.stringify(array),
+        );
+        return <Markdown fullWidth>{walkthrough?.steps[1]?.content}</Markdown>;
+      case 2:
+        array = JSON.parse(localStorage.getItem("HistoriqueInitialWorkflow"));
+        array.push(2 + 1);
+        localStorage.setItem(
+          "HistoriqueInitialWorkflow",
+          JSON.stringify(array),
+        );
+        return <Markdown fullWidth>{walkthrough?.steps[2]?.content}</Markdown>;
+      default:
+        return null;
+    }
+  };
+  const steps = [
+    walkthrough?.steps[0]?.name,
+    walkthrough?.steps[1]?.name,
+    walkthrough?.steps[2]?.name,
+  ];
+  useEffect(() => {
+    if (currentLanguages && currentLanguages.length > 0) {
+      getWalkthroughContent(currentLanguages).then();
+    }
+  }, [currentLanguages]);
+  const handleCreate = async () => {
+    setShowInitialWorkflow(false);
+    localStorage.setItem("HistoriqueInitialWorkflow", "[]");
+
+    localStorage.setItem("showInitialWorkflow", "initialWorkflowIsDisabled");
+  };
+
+  const handleClose = () => {
+    setShowInitialWorkflow(false);
+    localStorage.setItem("showInitialWorkflow", "initialWorkflowIsDisabled");
+  };
+  return (
+    showInitialWorkflow &&
+    walkthrough && (
+      <Grid2 item size={12}>
+        <Card elevation={1} sx={{ backgroundColor: "#E5F6FD" }}>
+          <CardContent>
+            <Typography variant="h5" component="div">
+              {walkthrough.title}
+            </Typography>
+            <PanStepperPicker
+              steps={steps}
+              initialStep={initStep}
+              renderStepContent={renderStepContent}
+              isStepValid={isStepValid}
+              handleCreate={handleCreate}
+              handleClose={handleClose}
+              requiredFieldsLabel={false}
+              primaryActionKey="close"
+              primaryButtonVariant="primary"
+              secondaryActionKey="back_button"
+              secondaryButtonVariant="secondary"
+            />
+          </CardContent>
+        </Card>
+      </Grid2>
+    )
+  );
+}


### PR DESCRIPTION
Now the walkthrough remembers at which step we were and if the walkthrough is not closed we will go back to that step 

I've also moved all the walkthrough related stuff inside its own component. I could in the future migrate to the RCL and reuse in other clients 