### PR TITLE
now fix linux build...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.5",
+        "@rollup/rollup-darwin-x64": "*",
         "pankosmia-rcl": "0.1.46",
         "pithekos-lib": "^0.11.20",
         "react": "^17.0.0 || ^18.0.0",
@@ -18,11 +19,14 @@
         "react-markdown": "^9.1.0"
       },
       "devDependencies": {
-        "@rollup/rollup-win32-x64-msvc": "^4.60.3",
         "@vitejs/plugin-react": "^4.3.4",
         "husky": "^9.1.7",
         "prettier": "3.8.1",
         "vite": "^6.0.7"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-x64": "^4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "^4.60.3"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -3387,13 +3391,12 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3687,8 +3690,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ]
@@ -15848,6 +15851,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react-markdown": "^9.1.0"
   },
   "devDependencies": {
-    "@rollup/rollup-win32-x64-msvc": "^4.60.3",
     "@vitejs/plugin-react": "^4.3.4",
     "husky": "^9.1.7",
     "prettier": "3.8.1",
@@ -42,5 +41,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-x64": "^4.60.3",
+    "@rollup/rollup-win32-x64-msvc": "^4.60.3"
   }
 }


### PR DESCRIPTION
This PR is:

1. `npm uninstall @rollup/rollup-win32-x64-msvc`
2. `npm install @rollup/rollup-win32-x64-msvc --save-optional`
3. `npm install @rollup/rollup-darwin-x64 --save-optional`

to fix this:
```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @rollup/rollup-win32-x64-msvc@4.60.3: wanted {"os":"win32","cpu":"x64"} (current: {"os":"linux","cpu":"x64"})
```