### PR TITLE
Configurable homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-app",
   "version": "0.2.0",
   "private": true,
-  "homepage": "/clients/main",
+  "homepage": "/clients/dashboard",
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -3,7 +3,7 @@
   "require": {
     "net": false
   },
-  "minServerVersion": "0.16.4",
+  "minServerVersion": "0.18.0",
 
   "i18n": {
     "title": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,5 +22,5 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: true,
   },
-  base: "/clients/main/",
+  base: "/clients/dashboard/",
 });


### PR DESCRIPTION
The edits here are few, but this enables new functionality in pankosmia_web which means that all clients are now optional and any client may be the homepage for a given product.

Previously, / resolved to /clients/main which was the url of core-clients-dashjboard. It was possible to make a different client at that url, but not to use the dashboard without it being the homepage.

In the new setup:
- there's a (currently) optional homepage field in product.json
- if that's not present we (currently) default to 'dashboard' which is the new name of this repo
- the server now looks for /clients/<product.homepage> on startup
- this client requires at least server 0.18.0 for this to work
- / now redirects to the homepage url
-  same for finding the favicon
- same for /clients/main

To test this
- should work as before with unmodified product.json
- should work as before with "dashboard" in product.json
- should work and open content with "content" in product.json
- should panic with "banana" in product.json

Once we have "desktop" as the default in desktop-app-template and downstream clients I'll make this field compulsory, at which point there will be no hardwired client urls in the server.

Note that to change the url of a client we now have to edit in both package.json and the vite config file. We should make the server use the vite config as the only source of truth one day.